### PR TITLE
Fix two typos in book chapters 05A and 06A

### DIFF
--- a/book/05A_Constants_variables_types_and_operations.md
+++ b/book/05A_Constants_variables_types_and_operations.md
@@ -457,7 +457,7 @@ The number of %'s and supplied values must be the same. If not you get a warning
 The format string requires 2 arguments, but 3 arguments are given.
 In this case only the first two values are displayed.
 
-If you want to print a literal %, replace the second % with \% as in line (4). To separate 2 arguments, you can always puy a 0 between the %, like so: `%0%` accepts two arguments. 
+If you want to print a literal %, replace the second % with \% as in line (4). To separate 2 arguments, you can always put a 0 between the %, like so: `%0%` accepts two arguments. 
 
 Although it is nearly always discarded, print returns the number of bytes printed, as shown in line (4B).
 

--- a/book/06A_bool_and_number_types.md
+++ b/book/06A_bool_and_number_types.md
@@ -81,7 +81,7 @@ A breakpoint was hit, but no debugger is attached.
 */
 ```
 
-Instead of always printing out if a bool expression is true of false, there is a handy shortcut with the **assert** procedure, defined in module _Basic_.
+Instead of always printing out if a bool expression is true or false, there is a handy shortcut with the **assert** procedure, defined in module _Basic_.
 
 `assert` takes an expression, and when this is true, nothing happens. When the expression is false, an assert stops the program execution with **Assertion failed** and the line where it happened, and prints out a stack trace. A message parameter after the expression is optional, but when there is one, it is also printed out (see the example in line (1)).
 So, assert is like: "verify this condition is still true at that point in the program, if not, stop it, because this is not normal".


### PR DESCRIPTION
Corrected two minor typos:
- "puy" -> "put" (05A)
- "true of false" -> "true or false" (06A)

